### PR TITLE
Fix update-repos-metadata script

### DIFF
--- a/src/scripts/update-repos-metadata.ts
+++ b/src/scripts/update-repos-metadata.ts
@@ -48,7 +48,7 @@ const updateReposMetadata = async () => {
   // select repo with oldest metadata
   const repos = await getXataClient()
     .db.os_repositories.select(["url", "id"])
-    .sort("xata.updatedAt", "desc")
+    .sort("xata.updatedAt", "asc")
     .getPaginated({
       pagination: { size: MAX_REPO_PER_EXECUTION },
     });


### PR DESCRIPTION
I noticed that the script was refreshing the metadata of the same repositories repeatedly, as it was fetching the most recently updated repositories first

To resolve this, I updated the sorting logic to prioritize repositories with the oldest `xata.updatedAt` timestamp

```ts
  const repos = await getXataClient()
    .db.os_repositories.select(["url", "id"])
    .sort("xata.updatedAt", "asc") // Instead of .sort("xata.updatedAt", "desc") 
```

> [!NOTE]  
> I didn’t test it in a production environment, so I recommend running the script first to verify that the sorting works as expected